### PR TITLE
[Chore] Remove view include lines

### DIFF
--- a/lib/rein.rb
+++ b/lib/rein.rb
@@ -13,7 +13,6 @@ require 'rein/constraint/exclusion'
 require 'rein/constraint/validate'
 require 'rein/schema'
 require 'rein/type/enum'
-require 'rein/view'
 
 module ActiveRecord
   class Migration # :nodoc:
@@ -31,6 +30,5 @@ module ActiveRecord
     include Rein::Constraint::Validate
     include Rein::Schema
     include Rein::Type::Enum
-    include Rein::View
   end
 end


### PR DESCRIPTION
We want to use `rein` gem to manage constraints, but it's conflicting with `scenic` gem that we're using to manage views.
In order to make them work together I suggest to maintain our own `rein` fork without views in it.